### PR TITLE
fix: disallow initializing es with already existing id

### DIFF
--- a/src/components/serializable-error.ts
+++ b/src/components/serializable-error.ts
@@ -3,7 +3,6 @@ import merge from 'deepmerge';
 import { pick } from 'lodash';
 import { define, ExtendableError } from '@eveble/core';
 import { DefinableMixin } from '../mixins/definable-mixin';
-
 import { types } from '../types';
 import { VersionableMixin } from '../mixins/versionable-mixin';
 import { HookableMixin } from '../mixins/hookable-mixin';

--- a/src/infrastructure/commit-store.ts
+++ b/src/infrastructure/commit-store.ts
@@ -191,6 +191,18 @@ export class CommitStore implements types.CommitStore {
   }
 
   /**
+   * Evaluates whether event sourceable with id already exists.
+   * @async
+   * @param eventSourceableId - Identifier as string or `Guid` instance.
+   * @returns Returns `true` if event sourceable exists, else `false`.
+   */
+  public async hasBySourceId(
+    eventSourceableId: string | Guid
+  ): Promise<boolean> {
+    return this.storage.hasBySourceId(eventSourceableId);
+  }
+
+  /**
    * Extracts all published events from `Commit`.
    * @param commits - List of instances implementing `Commit` interface.
    * @return List of all published events from commits.

--- a/src/infrastructure/event-sourceable-repository.ts
+++ b/src/infrastructure/event-sourceable-repository.ts
@@ -121,6 +121,18 @@ export class EventSourceableRepository
   }
 
   /**
+   * Evaluates whether event sourceable with id already exists.
+   * @async
+   * @param eventSourceableId - Identifier as string or `Guid` instance.
+   * @returns Returns `true` if event sourceable exists, else `false`.
+   */
+  public async hasBySourceId(
+    eventSourceableId: string | Guid
+  ): Promise<boolean> {
+    return this.commitStore.hasBySourceId(eventSourceableId);
+  }
+
+  /**
    * Makes a snapshot of `EventSourceable`.
    * @async
    * @param eventSourceable - Instance implementing `EventSourceable` interface.

--- a/src/infrastructure/infrastructure-errors.ts
+++ b/src/infrastructure/infrastructure-errors.ts
@@ -124,6 +124,13 @@ export class UnresolvableIdentifierFromMessageError extends RouterError {
   }
 }
 
+@define('InitializingIdentifierAlreadyExistsError')
+export class InitializingIdentifierAlreadyExistsError extends RouterError {
+  constructor(routerName: string, id: string) {
+    super(`${routerName}: provided identifier ${id} is already in use`);
+  }
+}
+
 /*
 SNAPSHOOTING ERRORS
 */

--- a/src/infrastructure/storages/commit-mongodb-storage.ts
+++ b/src/infrastructure/storages/commit-mongodb-storage.ts
@@ -119,6 +119,19 @@ export class CommitMongoDBStorage implements types.CommitStorage {
   }
 
   /**
+   * Evaluates whether event sourceable with id already exists.
+   * @async
+   * @param eventSourceableId - Identifier as string or `Guid` instance.
+   * @returns Returns `true` if event sourceable exists, else `false`.
+   */
+  public async hasBySourceId(
+    eventSourceableId: string | Guid
+  ): Promise<boolean> {
+    const query = { sourceId: eventSourceableId.toString() };
+    return (await this.collection.findOne(query)) != null;
+  }
+
+  /**
    * Returns commit from MongoDB collection if exists by event sourceable's id for specific version offset.
    * @async
    * @param eventSourceableId - Identifier as string or `Guid` instance.

--- a/src/types.ts
+++ b/src/types.ts
@@ -716,6 +716,7 @@ export namespace types {
       EventSourceableType: EventSourceableType,
       eventSourceableId: string | Stringifiable
     ): Promise<EventSourceable | undefined>;
+    hasBySourceId(eventSourceableId: string | Stringifiable): Promise<boolean>;
     makeSnapshotOf(
       eventSourceable: EventSourceable
     ): Promise<string | undefined>;
@@ -736,6 +737,7 @@ export namespace types {
     ): Promise<Event[] | undefined>;
     getAllEvents(): Promise<Event[]>;
     findById(commitId: string): Promise<Commit | undefined>;
+    hasBySourceId(eventSourceableId: string | Stringifiable): Promise<boolean>;
   }
 
   export interface CommitStorage {
@@ -745,6 +747,7 @@ export namespace types {
     ): Promise<number | undefined>;
     generateId(): Promise<string>;
     findById(commitId: string): Promise<Commit | undefined>;
+    hasBySourceId(eventSourceableId: string | Stringifiable): Promise<boolean>;
     getCommits(
       eventSourceableId: string | Stringifiable,
       versionOffset: number


### PR DESCRIPTION
This PR fixes initialization of Event Sourceable with already existing already identifier.

---

## Review Checklist

### Basics

- [x] PR information has been filled
- [x] PR has been assigned
- [x] PR uses appropriate labels (`fix`)
- [ ] PR has a all necessary bug-description fields filled
- [ ] PR is peer reviewed <sup>**optional**</sup>
- [x] Commits contain a meaningful commit messages and fallow syntax of [Conventional Commits](http://www.conventionalcommits.org/)
- [x] On dependency change: `yarn.lock` file is updated and committed
- [x] `CHANGELOG.md` and references to project's version are unchanged(let [semantic-release](https://github.com/semantic-release/semantic-release) do the magic)

### Code Quality

- [x] Code is properly typed with TypeScript
- [x] Code `builds`(`yarn build`)
- [x] Code is `formatted`(`yarn test:format`)
- [x] Code is `linted`(`yarn test:lint`)
- [x] Code is unit `tested`(`yarn test:unit`)
- [x] Code is integration `tested`(`yarn test:integration`)

### Testing

- [x] New fix is covered by unit tests
- [x] New fix is covered by integration tests
- [x] All existing tests are still up-to-date

### After Review

- [x] Merge the PR
- [x] Delete the source branch
- [ ] Move the ticket to `done` <sup>**optional**</sup>